### PR TITLE
Use IMDSv2

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -126,7 +126,10 @@ class AWSIntegrationRequires(Endpoint):
         return self._instance_id
 
     def _imdv2_request(self, url):
-        token_req = Request(self._metadatav2_token_url, headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"})
+        token_req = Request(
+            self._metadatav2_token_url,
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
+        )
         setattr(token_req, "method", "PUT")
 
         with urlopen(token_req) as fd:

--- a/requires.py
+++ b/requires.py
@@ -147,7 +147,8 @@ class AWSIntegrationRequires(Endpoint):
             if cached:
                 self._region = cached
             else:
-                with urlopen(self._az_url) as fd:
+                req = self._imdv2_request(self._az_url)
+                with urlopen(req) as fd:
                     az = fd.read(READ_BLOCK_SIZE).decode('utf8')
                     self._region = az.rstrip(string.ascii_lowercase)
                 unitdata.kv().set(cache_key, self._region)

--- a/requires.py
+++ b/requires.py
@@ -23,7 +23,7 @@ import json
 import string
 from hashlib import sha256
 from urllib.parse import urljoin
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 
 from charmhelpers.core import unitdata
 
@@ -61,6 +61,7 @@ class AWSIntegrationRequires(Endpoint):
     """
     # the IP is the AWS metadata service, documented here:
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+    _metadatav2_token_url = 'http://169.254.169.254/latest/api/token'
     _metadata_url = 'http://169.254.169.254/latest/meta-data/'
     _instance_id_url = urljoin(_metadata_url, 'instance-id')
     _az_url = urljoin(_metadata_url, 'placement/availability-zone')
@@ -118,10 +119,19 @@ class AWSIntegrationRequires(Endpoint):
             if cached:
                 self._instance_id = cached
             else:
-                with urlopen(self._instance_id_url) as fd:
+                req = self._imdv2_request(self._instance_id_url)
+                with urlopen(req) as fd:
                     self._instance_id = fd.read(READ_BLOCK_SIZE).decode('utf8')
                 unitdata.kv().set(cache_key, self._instance_id)
         return self._instance_id
+
+    def _imdv2_request(self, url):
+        token_req = Request(self._metadatav2_token_url, headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"})
+        setattr(token_req, "method", "PUT")
+
+        with urlopen(token_req) as fd:
+            token = fd.read(READ_BLOCK_SIZE).decode('utf8')
+            return Request(url, headers={"X-aws-ec2-metadata-token": token})
 
     @property
     def region(self):


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/2012079 and https://github.com/juju-solutions/interface-aws-integration/issues/13

This PR fixes AWS integration support on Juju 3.1.1 by using IMDSv2, instead of IMDSv1 which is no longer supported on AWS instances created by Juju 3.1.1.

I've tested these changes with a Charmed Kubernetes deployment on Juju 3.1.1 on AWS. The deployment came up active/idle and I verified that I was able to create a simple LoadBalancer service and curl it.

I opted *not* to include any code for falling back to IMDSv1 because, as I understand it from the [IMDSv2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) IMDSv2 is always available regardless of how the instance is configured. If there is any lingering concern, I can give this a test deployment with Juju 2.9 on Monday.

Thanks @tlm for the diff to get this started!